### PR TITLE
fixes path issues with fly deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ python app.py
 
 Open your web browser and navigate to: `http://localhost:3000`
 
+ **Note**: For local development, the app serves at the root path for convenience. In production deployment (Fly.io), it serves under `/flux-agent`.
+
 ## Configuration Options
 
 The application provides configuration options through the web interface:

--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ from enum import Enum, auto
 
 import openai
 import websockets
-from flask import Flask, render_template, request
+from flask import Flask, Blueprint, render_template, request
 from flask_socketio import SocketIO, emit
 from deepgram import (
     DeepgramClient,
@@ -26,7 +26,7 @@ from deepgram import (
 )
 
 from config import (
-    HOST, PORT, DEBUG,
+    HOST, PORT, DEBUG, BASE_PATH,
     DEEPGRAM_API_KEY, OPENAI_API_KEY,
     FLUX_URL, FLUX_ENCODING, SAMPLE_RATE,
     OPENAI_LLM_MODEL, DEEPGRAM_TTS_MODEL,
@@ -44,8 +44,14 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Flask app setup
-app = Flask(__name__)
+# Handle static path for both local dev (empty BASE_PATH) and production
+static_path = f'{BASE_PATH}/static' if BASE_PATH else '/static'
+app = Flask(__name__, static_url_path=static_path)
 app.config['SECRET_KEY'] = os.urandom(24)
+
+# Create Blueprint for base path handling (None url_prefix for local dev)
+bp = Blueprint('flux_agent', __name__, url_prefix=BASE_PATH or None)
+
 socketio = SocketIO(app, cors_allowed_origins="*", async_mode='threading')
 
 # Global state management
@@ -264,12 +270,15 @@ async def generate_tts_audio(text: str, session_id: str, config: Dict[str, Any])
         return None
 
 # Flask routes
-@app.route('/')
+@bp.route('/')
 def index():
     """Serve the main application page."""
     return render_template('index.html',
                          tts_models=TTS_MODEL_OPTIONS,
                          llm_models=LLM_MODEL_OPTIONS)
+
+# Register Blueprint
+app.register_blueprint(bp)
 
 # Socket.IO event handlers
 @socketio.on('connect')

--- a/config.py
+++ b/config.py
@@ -26,6 +26,9 @@ HOST = "0.0.0.0"  # Bind to all interfaces for Fly.io deployment
 PORT = 3000
 DEBUG = True  # Enable debug mode for local development
 
+# Base path for sub-path deployment (empty for local dev, /flux-agent for production)
+BASE_PATH = os.getenv("BASE_PATH", "")
+
 # Conversation System Prompts
 SYSTEM_PROMPT = """You are a helpful voice assistant powered by Deepgram Flux and OpenAI.
 You should:

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,9 @@ auto_rollback = true
 
 [build]
 
+[env]
+BASE_PATH = "/flux-agent"
+
 [http_service]
 internal_port = 3000
 auto_stop_machines = "stop"


### PR DESCRIPTION
## **PR Summary: Add Native Sub-Path Support to Flux Agent Demo**

### **Problem**
The Flux Agent demo was returning 404 errors when accessed through the reverse proxy at `https://demos.dx.deepgram.com/flux-agent`. The Flask application expected requests at the root path `/`, but the Caddy proxy was forwarding requests with the `/flux-agent` prefix intact.

### **Solution**
Modified the Flask application to handle sub-path deployment natively (similar to the flux-streaming demo), rather than relying on proxy-level path rewriting.

### **Changes Made**

#### **1. Environment-Aware Configuration (`config.py`)**
- Added `BASE_PATH = os.getenv("BASE_PATH", "")` 
- Defaults to empty string for local development
- Set via environment variable in production

#### **2. Flask Application Structure (`app.py`)**
- **Blueprint Implementation**: Created `flux_agent` Blueprint with dynamic `url_prefix`
- **Smart Static Serving**: Configures `static_url_path` based on BASE_PATH
- **Route Migration**: Moved main route from `@app.route('/')` to `@bp.route('/')`

#### **3. Production Configuration (`fly.toml`)**
- Added `BASE_PATH = "/flux-agent"` environment variable for Fly.io deployment

#### **4. Documentation Updates (`README.md`)**
- Clarified that BASE_PATH is automatically handled
- Removed confusing optional environment variable instructions
- Added note about dual local/production behavior

#### **5. Caddy Configuration Consistency (`caddy.json`)**
- Reverted path rewriting approach to match flux-streaming demo
- Both demos now use simple reverse proxy without path manipulation

### **Testing**
- **Local Development**: `http://localhost:3000/` works as before
- **Production**: `https://demos.dx.deepgram.com/flux-agent/` now resolves correctly

### **Why This Approach**
This follows the same pattern as the flux-streaming demo, making the codebase more consistent and maintainable. Applications handle their own routing requirements rather than relying on infrastructure-level workarounds.

